### PR TITLE
Correct seconds numbers

### DIFF
--- a/contracts/HolyPaladinToken.sol
+++ b/contracts/HolyPaladinToken.sol
@@ -16,13 +16,13 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
     /** @notice Seconds in a Week */
     uint256 public constant WEEK = 604800;
     /** @notice Seconds in a Month */
-    uint256 public constant MONTH = 2629800;
+    uint256 public constant MONTH = 2628000;
     /** @notice 1e18 scale */
     uint256 public constant UNIT = 1e18;
     /** @notice Max BPS value (100%) */
     uint256 public constant MAX_BPS = 10000;
     /** @notice Seconds in a Year */
-    uint256 public constant ONE_YEAR = 31557600;
+    uint256 public constant ONE_YEAR = 31536000;
 
     /** @notice  Period to wait before unstaking tokens  */
     uint256 public constant COOLDOWN_PERIOD = 864000; // 10 days
@@ -34,9 +34,9 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
     uint256 public constant UNLOCK_DELAY = 1209600; // 2 weeks
 
     /** @notice Minimum duration of a Lock  */
-    uint256 public constant MIN_LOCK_DURATION = 7889400; // 3 months
+    uint256 public constant MIN_LOCK_DURATION = 7884000; // 3 months
     /** @notice Maximum duration of a Lock  */
-    uint256 public constant MAX_LOCK_DURATION = 63115200; // 2 years
+    uint256 public constant MAX_LOCK_DURATION = 63072000; // 2 years
 
     /** @notice Address of the PAL token  */
     IERC20 public immutable pal;

--- a/scripts/deploy/deploy_hpal.ts
+++ b/scripts/deploy/deploy_hpal.ts
@@ -28,7 +28,7 @@ const {
 const startDropPerSecond = ethers.utils.parseEther('0.005')
 const endDropPerSecond = ethers.utils.parseEther('0.00075')
 
-const dropDecreaseDuration = 63115200
+const dropDecreaseDuration = 63072000
 
 const baseLockBonusRatio = ethers.utils.parseEther('1')
 const minLockBonusRatio = ethers.utils.parseEther('2')

--- a/src/test/LockingHPAL.test.sol
+++ b/src/test/LockingHPAL.test.sol
@@ -30,7 +30,7 @@ contract LockingHPALTest is DSTest {
         //hPAL constructor parameters
         uint256 startDropPerSecond = 0.0005 * 1e18;
         uint256 endDropPerSecond = 0.00001 * 1e18;
-        uint256 dropDecreaseDuration = 63115200;
+        uint256 dropDecreaseDuration = 63072000;
         uint256 baseLockBonusRatio = 1 * 1e18;
         uint256 minLockBonusRatio = 2 * 1e18;
         uint256 maxLockBonusRatio = 6 * 1e18;
@@ -64,7 +64,7 @@ contract LockingHPALTest is DSTest {
         vm.prank(locker);
         hpal.stake(stakingAmount);
 
-        uint256 lockDuration = 31557600;
+        uint256 lockDuration = 31536000;
 
         HolyPaladinToken.TotalLock memory previousTotalLocked = hpal.getCurrentTotalLock();
 
@@ -134,7 +134,7 @@ contract LockingHPALTest is DSTest {
         vm.prank(locker);
         hpal.stake(stakingAmount);
 
-        uint256 lockDuration = 31557600;
+        uint256 lockDuration = 31536000;
 
         vm.prank(locker);
         hpal.lock(lockAmount, lockDuration);
@@ -291,7 +291,7 @@ contract LockingHPALTest is DSTest {
 
         uint256 lockAmount = 300 * 1e18;
 
-        uint256 lockDuration = 31557600;
+        uint256 lockDuration = 31536000;
 
         vm.prank(locker);
         hpal.lock(lockAmount, lockDuration);
@@ -382,7 +382,7 @@ contract LockingHPALTest is DSTest {
         vm.prank(locker);
         hpal.stake(stakingAmount);
 
-        uint256 lockDuration = 31557600;
+        uint256 lockDuration = 31536000;
 
         vm.prank(locker);
         hpal.lock(lockAmount, lockDuration);
@@ -472,7 +472,7 @@ contract LockingHPALTest is DSTest {
         vm.prank(locker);
         hpal.stake(stakingAmount);
 
-        uint256 lockDuration = 31557600;
+        uint256 lockDuration = 31536000;
 
         vm.prank(locker);
         hpal.lock(lockAmount, lockDuration);
@@ -560,7 +560,7 @@ contract LockingHPALTest is DSTest {
         vm.prank(locker);
         hpal.stake(stakingAmount);
 
-        uint256 lockDuration = 31557600;
+        uint256 lockDuration = 31536000;
 
         if(amount > stakingAmount || amount == 0) return;
 
@@ -603,7 +603,7 @@ contract LockingHPALTest is DSTest {
         vm.prank(locker);
         hpal.stake(stakingAmount);
 
-        uint256 lockDuration = 31557600;
+        uint256 lockDuration = 31536000;
 
         if(amount > stakingAmount || amount == 0) return;
 
@@ -661,7 +661,7 @@ contract LockingHPALTest is DSTest {
                 bytes("hPAL: Null amount")
             );
             vm.prank(locker);
-            hpal.stakeAndLock(amount, 31557600);
+            hpal.stakeAndLock(amount, 31536000);
 
             uint256 newBalance = pal.balanceOf(locker);
             uint256 newStakedBalance = hpal.balanceOf(locker);
@@ -687,7 +687,7 @@ contract LockingHPALTest is DSTest {
                 bytes("ERC20: transfer amount exceeds balance")
             );
             vm.prank(locker);
-            hpal.stakeAndLock(amount, 31557600);
+            hpal.stakeAndLock(amount, 31536000);
 
             uint256 newBalance = pal.balanceOf(locker);
             uint256 newStakedBalance = hpal.balanceOf(locker);
@@ -710,7 +710,7 @@ contract LockingHPALTest is DSTest {
         }
         else{
             vm.prank(locker);
-            uint256 returnAmount = hpal.stakeAndLock(amount, 31557600);
+            uint256 returnAmount = hpal.stakeAndLock(amount, 31536000);
 
             assertEq(returnAmount, amount);
 
@@ -729,7 +729,7 @@ contract LockingHPALTest is DSTest {
 
             assertEq(userLock.amount, amount);
             assertEq(userLock.startTimestamp, block.timestamp);
-            assertEq(userLock.duration, 31557600);
+            assertEq(userLock.duration, 31536000);
             assertEq(userLock.fromBlock, block.number);
             assertEq(newTotalLocked.total, previousTotalLocked.total + amount);
         }
@@ -747,7 +747,7 @@ contract LockingHPALTest is DSTest {
         hpal.stake(700 * 1e18);
 
         vm.prank(locker);
-        hpal.lock(300 * 1e18, 31557600);
+        hpal.lock(300 * 1e18, 31536000);
 
         uint256 previousBalance = pal.balanceOf(locker);
         uint256 previousStakedBalance = hpal.balanceOf(locker);
@@ -762,7 +762,7 @@ contract LockingHPALTest is DSTest {
                 bytes("hPAL: Null amount")
             );
             vm.prank(locker);
-            hpal.stakeAndIncreaseLock(amount, 31557600);
+            hpal.stakeAndIncreaseLock(amount, 31536000);
 
             assertEq(pal.balanceOf(locker), previousBalance);
             assertEq(hpal.balanceOf(locker), previousStakedBalance);
@@ -783,7 +783,7 @@ contract LockingHPALTest is DSTest {
                 bytes("ERC20: transfer amount exceeds balance")
             );
             vm.prank(locker);
-            hpal.stakeAndIncreaseLock(amount, 31557600);
+            hpal.stakeAndIncreaseLock(amount, 31536000);
 
             assertEq(pal.balanceOf(locker), previousBalance);
             assertEq(hpal.balanceOf(locker), previousStakedBalance);
@@ -801,7 +801,7 @@ contract LockingHPALTest is DSTest {
         }
         else{
             vm.prank(locker);
-            uint256 returnAmount = hpal.stakeAndIncreaseLock(amount, 31557600);
+            uint256 returnAmount = hpal.stakeAndIncreaseLock(amount, 31536000);
 
             assertEq(returnAmount, amount);
 
@@ -815,7 +815,7 @@ contract LockingHPALTest is DSTest {
 
             assertEq(userLock.amount, previousLock.amount + amount);
             assertEq(userLock.startTimestamp, previousLock.startTimestamp);
-            assertEq(userLock.duration, 31557600);
+            assertEq(userLock.duration, 31536000);
             assertEq(userLock.fromBlock, block.number);
             assertEq(newTotalLocked.total, previousTotalLocked.total + amount);
 
@@ -840,7 +840,7 @@ contract LockingHPALTest is DSTest {
         uint256 lockAmount = 300 * 1e18;
 
         vm.prank(locker);
-        hpal.lock(lockAmount, 31557600);
+        hpal.lock(lockAmount, 31536000);
 
         uint256 previousBalanceLocker = hpal.balanceOf(locker);
         uint256 previousAvailableBalanceLocker = hpal.availableBalanceOf(locker);

--- a/src/test/StakingHPAL.test.sol
+++ b/src/test/StakingHPAL.test.sol
@@ -30,7 +30,7 @@ contract StakingHPALTest is DSTest {
         //hPAL constructor parameters
         uint256 startDropPerSecond = 0.0005 * 1e18;
         uint256 endDropPerSecond = 0.00001 * 1e18;
-        uint256 dropDecreaseDuration = 63115200;
+        uint256 dropDecreaseDuration = 63072000;
         uint256 baseLockBonusRatio = 1 * 1e18;
         uint256 minLockBonusRatio = 2 * 1e18;
         uint256 maxLockBonusRatio = 6 * 1e18;

--- a/test/0_HPAL_staking.test.ts
+++ b/test/0_HPAL_staking.test.ts
@@ -28,7 +28,7 @@ const mint_amount = ethers.utils.parseEther('10000000') // 10 M tokens
 const startDropPerSecond = ethers.utils.parseEther('0.0005')
 const endDropPerSecond = ethers.utils.parseEther('0.00001')
 
-const dropDecreaseDuration = 63115200
+const dropDecreaseDuration = 63072000
 
 const baseLockBonusRatio = ethers.utils.parseEther('1')
 const minLockBonusRatio = ethers.utils.parseEther('2')
@@ -96,8 +96,8 @@ describe('HolyPaladinToken contract tests - Base & Staking', () => {
         expect(await hPAL.COOLDOWN_PERIOD()).to.be.eq(864000)
         expect(await hPAL.UNSTAKE_PERIOD()).to.be.eq(432000)
         expect(await hPAL.UNLOCK_DELAY()).to.be.eq(1209600)
-        expect(await hPAL.MIN_LOCK_DURATION()).to.be.eq(7889400)
-        expect(await hPAL.MAX_LOCK_DURATION()).to.be.eq(63115200)
+        expect(await hPAL.MIN_LOCK_DURATION()).to.be.eq(7884000)
+        expect(await hPAL.MAX_LOCK_DURATION()).to.be.eq(63072000)
 
     });
 

--- a/test/1_HPAL_locking.test.ts
+++ b/test/1_HPAL_locking.test.ts
@@ -32,7 +32,7 @@ const WEEK = 604800
 const startDropPerSecond = ethers.utils.parseEther('0.0005')
 const endDropPerSecond = ethers.utils.parseEther('0.00001')
 
-const dropDecreaseDuration = 63115200
+const dropDecreaseDuration = 63072000
 
 const baseLockBonusRatio = ethers.utils.parseEther('1')
 const minLockBonusRatio = ethers.utils.parseEther('2')
@@ -101,8 +101,8 @@ describe('HolyPaladinToken contract tests - Locking', () => {
         expect(await hPAL.COOLDOWN_PERIOD()).to.be.eq(864000)
         expect(await hPAL.UNSTAKE_PERIOD()).to.be.eq(432000)
         expect(await hPAL.UNLOCK_DELAY()).to.be.eq(1209600)
-        expect(await hPAL.MIN_LOCK_DURATION()).to.be.eq(7889400)
-        expect(await hPAL.MAX_LOCK_DURATION()).to.be.eq(63115200)
+        expect(await hPAL.MIN_LOCK_DURATION()).to.be.eq(7884000)
+        expect(await hPAL.MAX_LOCK_DURATION()).to.be.eq(63072000)
 
     });
 
@@ -128,19 +128,19 @@ describe('HolyPaladinToken contract tests - Locking', () => {
 
         const lock_amount = ethers.utils.parseEther('700')
 
-        const lock_duration = 31557600
+        const lock_duration = 31536000
 
         const smaller_lock_amount = ethers.utils.parseEther('500')
 
-        const smaller_lock_duration = 15780000
+        const smaller_lock_duration = 15768000
 
         const bigger_lock_amount = ethers.utils.parseEther('850')
 
         const bigger_lock_duration = 47340000
 
         const estimateBonusRatio = async (duration: number) => {
-            const MAX_LOCK_DURATION = 63115200
-            const MIN_LOCK_DURATION = 7889400
+            const MAX_LOCK_DURATION = 63072000
+            const MIN_LOCK_DURATION = 7884000
             let durationRatio = UNIT.mul(duration - MIN_LOCK_DURATION).div(MAX_LOCK_DURATION - MIN_LOCK_DURATION)
             let mult = minLockBonusRatio.add((maxLockBonusRatio.sub(minLockBonusRatio)).mul(durationRatio).div(UNIT))
             return mult
@@ -645,7 +645,7 @@ describe('HolyPaladinToken contract tests - Locking', () => {
 
         const lock_amount = ethers.utils.parseEther('700')
 
-        const lock_duration = 31557600
+        const lock_duration = 31536000
 
         const smaller_lock_amount = ethers.utils.parseEther('500')
 
@@ -724,9 +724,9 @@ describe('HolyPaladinToken contract tests - Locking', () => {
 
         const lock_amount = ethers.utils.parseEther('700')
 
-        const lock_duration = 31557600
+        const lock_duration = 31536000
 
-        const smaller_lock_duration = 15780000
+        const smaller_lock_duration = 15768000
 
         const bigger_lock_duration = 47340000
 
@@ -815,7 +815,7 @@ describe('HolyPaladinToken contract tests - Locking', () => {
 
         const lock_amount = ethers.utils.parseEther('1000')
 
-        const lock_duration = 31557600
+        const lock_duration = 31536000
 
         const bigger_lock_duration = 47340000
 
@@ -1014,7 +1014,7 @@ describe('HolyPaladinToken contract tests - Locking', () => {
 
         const lock_amount = ethers.utils.parseEther('700')
 
-        const lock_duration = 31557600
+        const lock_duration = 31536000
 
         const bigger_lock_duration = 47340000
 
@@ -1437,7 +1437,7 @@ describe('HolyPaladinToken contract tests - Locking', () => {
 
         const lock_amount2 = ethers.utils.parseEther('300')
 
-        const lock_duration = 31557600
+        const lock_duration = 31536000
 
         beforeEach(async () => {
 
@@ -1582,7 +1582,7 @@ describe('HolyPaladinToken contract tests - Locking', () => {
 
         const lock_amount2 = ethers.utils.parseEther('500')
 
-        const lock_duration = 31557600
+        const lock_duration = 31536000
 
         beforeEach(async () => {
 
@@ -1716,19 +1716,19 @@ describe('HolyPaladinToken contract tests - Locking', () => {
 
         const lock_amount = ethers.utils.parseEther('700')
 
-        const lock_duration = 31557600
+        const lock_duration = 31536000
 
         const smaller_lock_amount = ethers.utils.parseEther('500')
 
-        const smaller_lock_duration = 15780000
+        const smaller_lock_duration = 15768000
 
         const bigger_lock_amount = ethers.utils.parseEther('850')
 
         const bigger_lock_duration = 47340000
 
         const estimateBonusRatio = async (duration: number) => {
-            const MAX_LOCK_DURATION = 63115200
-            const MIN_LOCK_DURATION = 7889400
+            const MAX_LOCK_DURATION = 63072000
+            const MIN_LOCK_DURATION = 7884000
             let durationRatio = UNIT.mul(duration - MIN_LOCK_DURATION).div(MAX_LOCK_DURATION - MIN_LOCK_DURATION)
             let mult = minLockBonusRatio.add((maxLockBonusRatio.sub(minLockBonusRatio)).mul(durationRatio).div(UNIT))
             return mult
@@ -1943,13 +1943,13 @@ describe('HolyPaladinToken contract tests - Locking', () => {
 
         const lock_amount = ethers.utils.parseEther('700')
 
-        const lock_duration = 31557600
+        const lock_duration = 31536000
 
         const extra_lock_amount = ethers.utils.parseEther('250')
 
         const bigger_lock_amount = ethers.utils.parseEther('450')
 
-        const smaller_lock_duration = 15780000
+        const smaller_lock_duration = 15768000
 
         const bigger_lock_duration = 47340000
 

--- a/test/2_hPAL_rewards.test.ts
+++ b/test/2_hPAL_rewards.test.ts
@@ -33,12 +33,12 @@ const UNIT = ethers.utils.parseEther('1')
 
 const WEEK = 604800
 
-const MONTH = 2629800
+const MONTH = 2628000
 
 const startDropPerSecond = ethers.utils.parseEther('0.0005')
 const endDropPerSecond = ethers.utils.parseEther('0.00001')
 
-const dropDecreaseDuration = 63115200
+const dropDecreaseDuration = 63072000
 
 const baseLockBonusRatio = ethers.utils.parseEther('1')
 const minLockBonusRatio = ethers.utils.parseEther('2')
@@ -128,8 +128,8 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
         expect(await hPAL.claimableRewards(user2.address)).to.be.eq(0)
         expect(await hPAL.rewardsLastUpdate(user2.address)).to.be.eq(0)
 
-        expect(await hPAL.MONTH()).to.be.eq(2629800)
-        expect(await hPAL.ONE_YEAR()).to.be.eq(31557600)
+        expect(await hPAL.MONTH()).to.be.eq(2628000)
+        expect(await hPAL.ONE_YEAR()).to.be.eq(31536000)
     });
 
 
@@ -139,7 +139,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
 
         const lock_amount = ethers.utils.parseEther('700')
 
-        const lock_duration = 31557600
+        const lock_duration = 31536000
 
         const transfer_amount = ethers.utils.parseEther('200')
 
@@ -410,7 +410,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
 
         const lock_amount = ethers.utils.parseEther('650')
 
-        const lock_duration = 31557600
+        const lock_duration = 31536000
 
         const transfer_amount = ethers.utils.parseEther('200')
 
@@ -607,7 +607,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
 
         const lock_amount = ethers.utils.parseEther('650')
 
-        const lock_duration = 31557600
+        const lock_duration = 31536000
 
         const bigger_lock_amount = ethers.utils.parseEther('1200')
 
@@ -615,8 +615,8 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
 
         const transfer_amount = ethers.utils.parseEther('200')
 
-        const MIN_LOCK_DURATION = 7889400
-        const MAX_LOCK_DURATION = 63115200
+        const MIN_LOCK_DURATION = 7884000
+        const MAX_LOCK_DURATION = 63072000
 
         const estimateBonusRatio = async (duration: number) => {
             let durationRatio = UNIT.mul(duration - MIN_LOCK_DURATION).div(MAX_LOCK_DURATION - MIN_LOCK_DURATION)

--- a/test/3_hPAL_admin_methods.test.ts
+++ b/test/3_hPAL_admin_methods.test.ts
@@ -27,7 +27,7 @@ const mint_amount = ethers.utils.parseEther('10000000') // 10 M tokens
 const startDropPerSecond = ethers.utils.parseEther('0.0005')
 const endDropPerSecond = ethers.utils.parseEther('0.00001')
 
-const dropDecreaseDuration = 63115200
+const dropDecreaseDuration = 63072000
 
 const MONTH = 2629800
 
@@ -97,8 +97,8 @@ describe('HolyPaladinToken contract tests - Admin', () => {
         expect(await hPAL.COOLDOWN_PERIOD()).to.be.eq(864000)
         expect(await hPAL.UNSTAKE_PERIOD()).to.be.eq(432000)
         expect(await hPAL.UNLOCK_DELAY()).to.be.eq(1209600)
-        expect(await hPAL.MIN_LOCK_DURATION()).to.be.eq(7889400)
-        expect(await hPAL.MAX_LOCK_DURATION()).to.be.eq(63115200)
+        expect(await hPAL.MIN_LOCK_DURATION()).to.be.eq(7884000)
+        expect(await hPAL.MAX_LOCK_DURATION()).to.be.eq(63072000)
 
     });
 
@@ -190,7 +190,7 @@ describe('HolyPaladinToken contract tests - Admin', () => {
 
         const lock_amount = ethers.utils.parseEther('700')
 
-        const lock_duration = 31556952
+        const lock_duration = 31536000
 
         beforeEach(async () => {
 


### PR DESCRIPTION
Fix issue from code-423n4 contest:
hPAL: correct amount of seconds for temporal variables (year, month, ...)
Put correct amount of seconds for a year, for a month, and for all values based on it
+ update tests with correct values