### PR TITLE
Unstake Window down to 2 days

### DIFF
--- a/contracts/HolyPaladinToken.sol
+++ b/contracts/HolyPaladinToken.sol
@@ -28,7 +28,7 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
     uint256 public constant COOLDOWN_PERIOD = 864000; // 10 days
     /** @notice  Duration of the unstaking period
     After that period, unstaking cooldown is expired  */
-    uint256 public constant UNSTAKE_PERIOD = 432000; // 5 days
+    uint256 public constant UNSTAKE_PERIOD = 172800; // 2 days
 
     /** @notice Period to unlock/re-lock tokens without possibility of punishement   */
     uint256 public constant UNLOCK_DELAY = 1209600; // 2 weeks

--- a/test/0_HPAL_staking.test.ts
+++ b/test/0_HPAL_staking.test.ts
@@ -94,7 +94,7 @@ describe('HolyPaladinToken contract tests - Base & Staking', () => {
 
         //constants
         expect(await hPAL.COOLDOWN_PERIOD()).to.be.eq(864000)
-        expect(await hPAL.UNSTAKE_PERIOD()).to.be.eq(432000)
+        expect(await hPAL.UNSTAKE_PERIOD()).to.be.eq(172800)
         expect(await hPAL.UNLOCK_DELAY()).to.be.eq(1209600)
         expect(await hPAL.MIN_LOCK_DURATION()).to.be.eq(7889400)
         expect(await hPAL.MAX_LOCK_DURATION()).to.be.eq(63115200)

--- a/test/1_HPAL_locking.test.ts
+++ b/test/1_HPAL_locking.test.ts
@@ -99,7 +99,7 @@ describe('HolyPaladinToken contract tests - Locking', () => {
 
         //constants
         expect(await hPAL.COOLDOWN_PERIOD()).to.be.eq(864000)
-        expect(await hPAL.UNSTAKE_PERIOD()).to.be.eq(432000)
+        expect(await hPAL.UNSTAKE_PERIOD()).to.be.eq(172800)
         expect(await hPAL.UNLOCK_DELAY()).to.be.eq(1209600)
         expect(await hPAL.MIN_LOCK_DURATION()).to.be.eq(7889400)
         expect(await hPAL.MAX_LOCK_DURATION()).to.be.eq(63115200)

--- a/test/3_hPAL_admin_methods.test.ts
+++ b/test/3_hPAL_admin_methods.test.ts
@@ -95,7 +95,7 @@ describe('HolyPaladinToken contract tests - Admin', () => {
 
         //constants
         expect(await hPAL.COOLDOWN_PERIOD()).to.be.eq(864000)
-        expect(await hPAL.UNSTAKE_PERIOD()).to.be.eq(432000)
+        expect(await hPAL.UNSTAKE_PERIOD()).to.be.eq(172800)
         expect(await hPAL.UNLOCK_DELAY()).to.be.eq(1209600)
         expect(await hPAL.MIN_LOCK_DURATION()).to.be.eq(7889400)
         expect(await hPAL.MAX_LOCK_DURATION()).to.be.eq(63115200)


### PR DESCRIPTION
Fix issue from code-423n4 contest:
Reduce UNSTAKE_PERIOD to 2 days to prevent users to unstake through each others