### PR TITLE
Block number manipulation

### DIFF
--- a/contracts/HolyPaladinToken.sol
+++ b/contracts/HolyPaladinToken.sol
@@ -1056,6 +1056,30 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
         }
     }
 
+    function _writeUserLock(
+        address user,
+        uint256 amount,
+        uint256 startTimestamp,
+        uint256 duration
+    ) internal {
+        uint256 pos = userLocks[user].length;
+        if (pos > 0 && userLocks[user][pos - 1].fromBlock == block.number) {
+            UserLock storage currentUserLock = userLocks[user][pos - 1];
+            currentUserLock.amount = safe128(amount);
+            currentUserLock.duration = safe48(duration);
+            currentUserLock.startTimestamp = safe48(startTimestamp);
+        } else {
+            userLocks[user].push(
+                UserLock(
+                    safe128(amount),
+                    safe48(startTimestamp),
+                    safe48(duration),
+                    safe32(block.number)
+                )
+            );
+        }
+    }
+
     function _writeTotalLocked(uint256 newTotalLocked) internal {
         uint256 pos = totalLocks.length;
         if (pos > 0 && totalLocks[pos - 1].fromBlock == block.number) {
@@ -1190,12 +1214,7 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
                 // User locked, and then unlocked
                 // or user lock expired
 
-                userLocks[user].push(UserLock(
-                    safe128(amount),
-                    safe48(startTimestamp),
-                    safe48(duration),
-                    safe32(block.number)
-                ));
+                _writeUserLock(user, amount, startTimestamp, duration);
             }
             else {
                 // Update of the current Lock : increase amount or increase duration
@@ -1204,15 +1223,8 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
                 require(duration >=  currentUserLock.duration,"hPAL: smaller duration");
 
                 // If the method is called with INCREASE_AMOUNT, then we don't change the startTimestamp of the Lock
-
-                userLocks[user].push(UserLock(
-                    safe128(amount),
-                    action == LockAction.INCREASE_AMOUNT ? currentUserLock.startTimestamp : safe48(startTimestamp),
-                    safe48(duration),
-                    safe32(block.number)
-                ));
-
                 startTimestamp = action == LockAction.INCREASE_AMOUNT ? currentUserLock.startTimestamp : startTimestamp;
+                _writeUserLock(user, amount, startTimestamp, duration);
             }
 
             // If the duration is updated, re-calculate the multiplier for the Lock
@@ -1260,12 +1272,7 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
         userBonusRatioDecrease[user] = 0;
 
         // Set the user Lock as an empty Lock
-        userLocks[user].push(UserLock(
-            safe128(0),
-            safe48(block.timestamp),
-            safe48(0),
-            safe32(block.number)
-        ));
+        _writeUserLock(user, 0, block.timestamp, 0);
 
         emit Unlock(user, currentUserLock.amount, currentTotalLocked);
     }
@@ -1290,12 +1297,7 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
         _writeTotalLocked(currentTotalLocked);
 
         // Set an empty Lock for the user
-        userLocks[user].push(UserLock(
-            safe128(0),
-            safe48(block.timestamp),
-            safe48(0),
-            safe32(block.number)
-        ));
+        _writeUserLock(user, 0, block.timestamp, 0);
 
         // Remove the bonus multiplier
         userCurrentBonusRatio[user] = 0;

--- a/contracts/HolyPaladinToken.sol
+++ b/contracts/HolyPaladinToken.sol
@@ -1204,7 +1204,7 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
         else {
             // Get the current user Lock
             uint256 currentUserLockIndex = userLocks[user].length - 1;
-            UserLock storage currentUserLock = userLocks[user][currentUserLockIndex];
+            UserLock memory currentUserLock = userLocks[user][currentUserLockIndex];
             // Calculate the end of the user current lock
             uint256 userCurrentLockEnd = currentUserLock.startTimestamp + currentUserLock.duration;
 
@@ -1257,7 +1257,7 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
         // Get the user current Lock
         // And calculate the end of the Lock
         uint256 currentUserLockIndex = userLocks[user].length - 1;
-        UserLock storage currentUserLock = userLocks[user][currentUserLockIndex];
+        UserLock memory currentUserLock = userLocks[user][currentUserLockIndex];
         uint256 userCurrentLockEnd = currentUserLock.startTimestamp + currentUserLock.duration;
 
         require(block.timestamp > userCurrentLockEnd, "hPAL: Not expired");
@@ -1284,7 +1284,7 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
         // Get the user to kick current Lock
         // and calculate the end of the Lock
         uint256 currentUserLockIndex = userLocks[user].length - 1;
-        UserLock storage currentUserLock = userLocks[user][currentUserLockIndex];
+        UserLock memory currentUserLock = userLocks[user][currentUserLockIndex];
         uint256 userCurrentLockEnd = currentUserLock.startTimestamp + currentUserLock.duration;
 
         require(block.timestamp > userCurrentLockEnd, "hPAL: Not expired");

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -55,7 +55,8 @@ const config: HardhatUserConfig = {
       forking: {
         url: "https://eth-mainnet.alchemyapi.io/v2/" + (process.env.ALCHEMY_API_KEY || ''),
         blockNumber: 13178506
-      }
+      },
+      allowUnlimitedContractSize: true,
     },
     kovan: {
       url: process.env.KOVAN_URI,

--- a/src/test/LockingHPAL.test.sol
+++ b/src/test/LockingHPAL.test.sol
@@ -139,6 +139,8 @@ contract LockingHPALTest is DSTest {
         vm.prank(locker);
         hpal.lock(lockAmount, lockDuration);
 
+        utils.mineBlocks(1);
+
         HolyPaladinToken.UserLock memory previousLock = hpal.getUserLock(locker);
         HolyPaladinToken.TotalLock memory previousTotalLocked = hpal.getCurrentTotalLock();
 
@@ -296,6 +298,8 @@ contract LockingHPALTest is DSTest {
         vm.prank(locker);
         hpal.lock(lockAmount, lockDuration);
 
+        utils.mineBlocks(10);
+
         HolyPaladinToken.UserLock memory previousLock = hpal.getUserLock(locker);
 
         HolyPaladinToken.TotalLock memory previousTotalLocked = hpal.getCurrentTotalLock();
@@ -358,7 +362,7 @@ contract LockingHPALTest is DSTest {
             assertEq(userLock.amount, previousLock.amount);
             assertEq(userLock.startTimestamp, previousLock.startTimestamp);
             assertEq(userLock.duration, duration);
-            assertEq(userLock.fromBlock, previousLock.fromBlock);
+            assertEq(userLock.fromBlock, block.number);
             assertEq(newTotalLocked.total, previousTotalLocked.total);
 
         }
@@ -386,6 +390,8 @@ contract LockingHPALTest is DSTest {
 
         vm.prank(locker);
         hpal.lock(lockAmount, lockDuration);
+
+        utils.mineBlocks(1);
 
         HolyPaladinToken.UserLock memory previousLock = hpal.getUserLock(locker);
         HolyPaladinToken.TotalLock memory previousTotalLocked = hpal.getCurrentTotalLock();
@@ -477,6 +483,8 @@ contract LockingHPALTest is DSTest {
         vm.prank(locker);
         hpal.lock(lockAmount, lockDuration);
 
+        utils.mineBlocks(1);
+
         HolyPaladinToken.UserLock memory previousLock = hpal.getUserLock(locker);
         HolyPaladinToken.TotalLock memory previousTotalLocked = hpal.getCurrentTotalLock();
         
@@ -567,6 +575,8 @@ contract LockingHPALTest is DSTest {
         vm.prank(locker);
         hpal.lock(amount, lockDuration);
 
+        utils.mineBlocks(1);
+
         HolyPaladinToken.TotalLock memory previousTotalLocked = hpal.getCurrentTotalLock();
 
         utils.advanceTime(lockDuration + 10);
@@ -609,6 +619,8 @@ contract LockingHPALTest is DSTest {
 
         vm.prank(locker);
         hpal.lock(amount, lockDuration);
+
+        utils.mineBlocks(1);
 
         uint256 previousLockerBalance = hpal.balanceOf(locker);
         uint256 previousLockerKicker = hpal.balanceOf(kicker);
@@ -749,6 +761,8 @@ contract LockingHPALTest is DSTest {
         vm.prank(locker);
         hpal.lock(300 * 1e18, 31557600);
 
+        utils.mineBlocks(1);
+
         uint256 previousBalance = pal.balanceOf(locker);
         uint256 previousStakedBalance = hpal.balanceOf(locker);
         uint256 previousContractBalance = pal.balanceOf(address(hpal));
@@ -841,6 +855,8 @@ contract LockingHPALTest is DSTest {
 
         vm.prank(locker);
         hpal.lock(lockAmount, 31557600);
+
+        utils.mineBlocks(1);
 
         uint256 previousBalanceLocker = hpal.balanceOf(locker);
         uint256 previousAvailableBalanceLocker = hpal.availableBalanceOf(locker);

--- a/src/test/LockingHPAL.test.sol
+++ b/src/test/LockingHPAL.test.sol
@@ -139,8 +139,6 @@ contract LockingHPALTest is DSTest {
         vm.prank(locker);
         hpal.lock(lockAmount, lockDuration);
 
-        utils.mineBlocks(1);
-
         HolyPaladinToken.UserLock memory previousLock = hpal.getUserLock(locker);
         HolyPaladinToken.TotalLock memory previousTotalLocked = hpal.getCurrentTotalLock();
 
@@ -298,8 +296,6 @@ contract LockingHPALTest is DSTest {
         vm.prank(locker);
         hpal.lock(lockAmount, lockDuration);
 
-        utils.mineBlocks(10);
-
         HolyPaladinToken.UserLock memory previousLock = hpal.getUserLock(locker);
 
         HolyPaladinToken.TotalLock memory previousTotalLocked = hpal.getCurrentTotalLock();
@@ -391,8 +387,6 @@ contract LockingHPALTest is DSTest {
         vm.prank(locker);
         hpal.lock(lockAmount, lockDuration);
 
-        utils.mineBlocks(1);
-
         HolyPaladinToken.UserLock memory previousLock = hpal.getUserLock(locker);
         HolyPaladinToken.TotalLock memory previousTotalLocked = hpal.getCurrentTotalLock();
         
@@ -482,8 +476,6 @@ contract LockingHPALTest is DSTest {
 
         vm.prank(locker);
         hpal.lock(lockAmount, lockDuration);
-
-        utils.mineBlocks(1);
 
         HolyPaladinToken.UserLock memory previousLock = hpal.getUserLock(locker);
         HolyPaladinToken.TotalLock memory previousTotalLocked = hpal.getCurrentTotalLock();
@@ -575,8 +567,6 @@ contract LockingHPALTest is DSTest {
         vm.prank(locker);
         hpal.lock(amount, lockDuration);
 
-        utils.mineBlocks(1);
-
         HolyPaladinToken.TotalLock memory previousTotalLocked = hpal.getCurrentTotalLock();
 
         utils.advanceTime(lockDuration + 10);
@@ -619,8 +609,6 @@ contract LockingHPALTest is DSTest {
 
         vm.prank(locker);
         hpal.lock(amount, lockDuration);
-
-        utils.mineBlocks(1);
 
         uint256 previousLockerBalance = hpal.balanceOf(locker);
         uint256 previousLockerKicker = hpal.balanceOf(kicker);
@@ -761,8 +749,6 @@ contract LockingHPALTest is DSTest {
         vm.prank(locker);
         hpal.lock(300 * 1e18, 31557600);
 
-        utils.mineBlocks(1);
-
         uint256 previousBalance = pal.balanceOf(locker);
         uint256 previousStakedBalance = hpal.balanceOf(locker);
         uint256 previousContractBalance = pal.balanceOf(address(hpal));
@@ -855,8 +841,6 @@ contract LockingHPALTest is DSTest {
 
         vm.prank(locker);
         hpal.lock(lockAmount, 31557600);
-
-        utils.mineBlocks(1);
 
         uint256 previousBalanceLocker = hpal.balanceOf(locker);
         uint256 previousAvailableBalanceLocker = hpal.availableBalanceOf(locker);


### PR DESCRIPTION
If DelegateCheckpoints, UserLocks or TotalLocks already exist for the current block, update the Struct instead of pushing a new one
+ internal methods to write those Structs into storage