### PR TITLE
Math precision

### DIFF
--- a/contracts/HolyPaladinToken.sol
+++ b/contracts/HolyPaladinToken.sol
@@ -1113,6 +1113,9 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
     ) internal view returns(uint256) {
         uint256 receiverCooldown = cooldowns[receiver];
 
+        // If amount is 0, there is not transfer, no need to change the receiver cooldown
+        if(amount == 0) return receiverCooldown;
+
         // If receiver has no cooldown, no need to set a new one
         if(receiverCooldown == 0) return 0;
 

--- a/contracts/HolyPaladinToken.sol
+++ b/contracts/HolyPaladinToken.sol
@@ -719,6 +719,9 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
             if(currentDropPerSecond != endDropPerSecond) {
                 currentDropPerSecond = endDropPerSecond;
                 lastDropUpdate = block.timestamp;
+                // Here we set the current timestamp isntead of increasing by a number of month,
+                // since we exceeded the dropDecreaseDuration, and the value could be updated
+                // outside a monthly process
             }
 
             return endDropPerSecond;
@@ -736,7 +739,7 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
         uint256 newDropPerSecond = currentDropPerSecond - dropPerSecondDecrease > endDropPerSecond ? currentDropPerSecond - dropPerSecondDecrease : endDropPerSecond;
     
         currentDropPerSecond = newDropPerSecond;
-        lastDropUpdate = block.timestamp;
+        lastDropUpdate = lastDropUpdate + (nbMonthEllapsed * MONTH);
 
         return newDropPerSecond;
     }

--- a/contracts/HolyPaladinToken.sol
+++ b/contracts/HolyPaladinToken.sol
@@ -726,7 +726,7 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
 
         if(block.timestamp < lastDropUpdate + MONTH) return currentDropPerSecond; // Update it once a month
 
-        uint256 dropDecreasePerMonth = (startDropPerSecond - endDropPerSecond) / (dropDecreaseDuration / MONTH);
+        uint256 dropDecreasePerMonth = ((startDropPerSecond - endDropPerSecond) * MONTH) / (dropDecreaseDuration);
         uint256 nbMonthEllapsed = (block.timestamp - lastDropUpdate) / MONTH;
 
         uint256 dropPerSecondDecrease = dropDecreasePerMonth * nbMonthEllapsed;
@@ -839,7 +839,7 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
                             // and calculate the locking rewards based on the locked balance & 
                             // a ratio based on the rpevious one and the newly calculated one
                             vars.periodBonusRatio = newBonusRatio + ((vars.userRatioDecrease + vars.bonusRatioDecrease) / 2);
-                            lockingRewards = (userLockedBalance * ((indexDiff * vars.periodBonusRatio) / UNIT)) / UNIT;
+                            lockingRewards = ((userLockedBalance * (indexDiff * vars.periodBonusRatio)) / UNIT) / UNIT;
                         }
                     }
 

--- a/test/2_hPAL_rewards.test.ts
+++ b/test/2_hPAL_rewards.test.ts
@@ -833,7 +833,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
                 decrease_multiplier.mul(ellapsed_time).add(decrease_multiplier).div(2)
             )
 
-            estimated_accrued_rewards = ((update_index.sub(lock_index)).mul(estimated_multiplier_period).div(UNIT)).mul(stake_amount).div(UNIT)
+            estimated_accrued_rewards = ((update_index.sub(lock_index)).mul(estimated_multiplier_period)).mul(stake_amount).div(UNIT).div(UNIT)
 
             expect(user_rewards3).to.be.eq(user_rewards2.add(estimated_accrued_rewards))
 
@@ -853,7 +853,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
                 decrease_multiplier.mul(ellapsed_time2).add(decrease_multiplier).div(2)
             )
 
-            estimated_accrued_rewards = ((update_index2.sub(update_index)).mul(estimated_multiplier_period2).div(UNIT)).mul(stake_amount).div(UNIT)
+            estimated_accrued_rewards = ((update_index2.sub(update_index)).mul(estimated_multiplier_period2)).mul(stake_amount).div(UNIT).div(UNIT)
 
             expect(user_rewards4).to.be.eq(user_rewards3.add(estimated_accrued_rewards))
         });
@@ -900,7 +900,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
                 decrease_multiplier.mul(ellapsed_time).add(decrease_multiplier).div(2)
             )
 
-            let estimated_locking_accrued_rewards = ((update_index.sub(lock_index)).mul(estimated_multiplier_period).div(UNIT)).mul(lock_amount).div(UNIT)
+            let estimated_locking_accrued_rewards = ((update_index.sub(lock_index)).mul(estimated_multiplier_period)).mul(lock_amount).div(UNIT).div(UNIT)
 
             estimated_accrued_rewards = estimated_locking_accrued_rewards.add(update_index.sub(lock_index).mul(staked_balance).div(UNIT))
 
@@ -922,7 +922,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
                 decrease_multiplier.mul(ellapsed_time2).add(decrease_multiplier).div(2)
             )
 
-            estimated_locking_accrued_rewards = ((update_index2.sub(update_index)).mul(estimated_multiplier_period2).div(UNIT)).mul(lock_amount).div(UNIT)
+            estimated_locking_accrued_rewards = ((update_index2.sub(update_index)).mul(estimated_multiplier_period2)).mul(lock_amount).div(UNIT).div(UNIT)
 
             estimated_accrued_rewards = estimated_locking_accrued_rewards.add(update_index2.sub(update_index).mul(staked_balance).div(UNIT))
 
@@ -973,7 +973,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
                 decrease_multiplier.mul(ellapsed_time).add(decrease_multiplier).div(2)
             )
 
-            let estimated_locking_accrued_rewards = ((update_index.sub(lock_index)).mul(estimated_multiplier_period).div(UNIT)).mul(lock_amount).div(UNIT)
+            let estimated_locking_accrued_rewards = ((update_index.sub(lock_index)).mul(estimated_multiplier_period)).mul(lock_amount).div(UNIT).div(UNIT)
 
             estimated_accrued_rewards = estimated_locking_accrued_rewards.add(update_index.sub(lock_index).mul(staked_balance).div(UNIT))
 
@@ -995,7 +995,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
                 decrease_multiplier.mul(ellapsed_time2).add(decrease_multiplier).div(2)
             )
 
-            estimated_locking_accrued_rewards = ((update_index2.sub(update_index)).mul(estimated_multiplier_period2).div(UNIT)).mul(lock_amount).div(UNIT)
+            estimated_locking_accrued_rewards = ((update_index2.sub(update_index)).mul(estimated_multiplier_period2)).mul(lock_amount).div(UNIT).div(UNIT)
 
             estimated_accrued_rewards = estimated_locking_accrued_rewards.add(update_index2.sub(update_index).mul(staked_balance).div(UNIT))
 
@@ -1046,7 +1046,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
                 decrease_multiplier.mul(ellapsed_time).add(decrease_multiplier).div(2)
             )
 
-            let estimated_locking_accrued_rewards = ((update_index.sub(lock_index)).mul(estimated_multiplier_period).div(UNIT)).mul(lock_amount).div(UNIT)
+            let estimated_locking_accrued_rewards = ((update_index.sub(lock_index)).mul(estimated_multiplier_period)).mul(lock_amount).div(UNIT).div(UNIT)
 
             estimated_accrued_rewards = estimated_locking_accrued_rewards.add(update_index.sub(lock_index).mul(staked_balance).div(UNIT))
 
@@ -1068,7 +1068,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
                 decrease_multiplier.mul(ellapsed_time2).add(decrease_multiplier).div(2)
             )
 
-            estimated_locking_accrued_rewards = ((update_index2.sub(update_index)).mul(estimated_multiplier_period2).div(UNIT)).mul(lock_amount).div(UNIT)
+            estimated_locking_accrued_rewards = ((update_index2.sub(update_index)).mul(estimated_multiplier_period2)).mul(lock_amount).div(UNIT).div(UNIT)
 
             estimated_accrued_rewards = estimated_locking_accrued_rewards.add(update_index2.sub(update_index).mul(staked_balance).div(UNIT))
 
@@ -1252,7 +1252,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
                 decrease_multiplier.mul(ellapsed_time).add(decrease_multiplier).div(2)
             )
 
-            let estimated_locking_accrued_rewards = ((update_index.sub(lock_index)).mul(estimated_multiplier_period).div(UNIT)).mul(lock_amount).div(UNIT)
+            let estimated_locking_accrued_rewards = ((update_index.sub(lock_index)).mul(estimated_multiplier_period)).mul(lock_amount).div(UNIT).div(UNIT)
 
             estimated_accrued_rewards = estimated_locking_accrued_rewards.add(update_index.sub(lock_index).mul(staked_balance).div(UNIT))
 
@@ -1274,7 +1274,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
                 decrease_multiplier.mul(ellapsed_time2).add(decrease_multiplier).div(2)
             )
 
-            estimated_locking_accrued_rewards = ((unlock_index.sub(update_index)).mul(estimated_multiplier_period2).div(UNIT)).mul(lock_amount).div(UNIT)
+            estimated_locking_accrued_rewards = ((unlock_index.sub(update_index)).mul(estimated_multiplier_period2)).mul(lock_amount).div(UNIT).div(UNIT)
 
             estimated_accrued_rewards = estimated_locking_accrued_rewards.add(unlock_index.sub(update_index).mul(staked_balance).div(UNIT))
 
@@ -1334,7 +1334,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
                 decrease_multiplier.mul(ellapsed_time).add(decrease_multiplier).div(2)
             )
 
-            let estimated_locking_accrued_rewards = ((update_index.sub(lock_index)).mul(estimated_multiplier_period).div(UNIT)).mul(lock_amount).div(UNIT)
+            let estimated_locking_accrued_rewards = ((update_index.sub(lock_index)).mul(estimated_multiplier_period)).mul(lock_amount).div(UNIT).div(UNIT)
 
             estimated_accrued_rewards = estimated_locking_accrued_rewards.add(update_index.sub(lock_index).mul(staked_balance).div(UNIT))
 
@@ -1356,7 +1356,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
                 decrease_multiplier.mul(ellapsed_time2).add(decrease_multiplier).div(2)
             )
 
-            estimated_locking_accrued_rewards = ((kick_index.sub(update_index)).mul(estimated_multiplier_period2).div(UNIT)).mul(lock_amount).div(UNIT)
+            estimated_locking_accrued_rewards = ((kick_index.sub(update_index)).mul(estimated_multiplier_period2)).mul(lock_amount).div(UNIT).div(UNIT)
 
             estimated_accrued_rewards = estimated_locking_accrued_rewards.add(kick_index.sub(update_index).mul(staked_balance).div(UNIT))
 
@@ -1418,7 +1418,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
                 decrease_multiplier.mul(ellapsed_time).add(decrease_multiplier).div(2)
             )
 
-            let estimated_locking_accrued_rewards = ((update_index.sub(lock_index)).mul(estimated_multiplier_period).div(UNIT)).mul(lock_amount).div(UNIT)
+            let estimated_locking_accrued_rewards = ((update_index.sub(lock_index)).mul(estimated_multiplier_period)).mul(lock_amount).div(UNIT).div(UNIT)
 
             estimated_accrued_rewards = estimated_locking_accrued_rewards.add(update_index.sub(lock_index).mul(staked_balance).div(UNIT))
 
@@ -1440,7 +1440,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
                 estimated_current_multiplier.add(decrease_multiplier).div(2)
             )
 
-            estimated_locking_accrued_rewards = ((update2_index.sub(update_index)).mul(estimated_multiplier_period2).div(UNIT)).mul(lock_amount).div(UNIT)
+            estimated_locking_accrued_rewards = ((update2_index.sub(update_index)).mul(estimated_multiplier_period2)).mul(lock_amount).div(UNIT).div(UNIT)
 
             estimated_accrued_rewards = estimated_locking_accrued_rewards.add(update2_index.sub(update_index).mul(staked_balance).div(UNIT))
 
@@ -1543,7 +1543,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
                 decrease_multiplier.mul(ellapsed_time).add(decrease_multiplier).div(2)
             )
 
-            let estimated_locking_accrued_rewards = ((update_index.sub(lock_index)).mul(estimated_multiplier_period).div(UNIT)).mul(lock_amount).div(UNIT)
+            let estimated_locking_accrued_rewards = ((update_index.sub(lock_index)).mul(estimated_multiplier_period)).mul(lock_amount).div(UNIT).div(UNIT)
 
             estimated_accrued_rewards = estimated_locking_accrued_rewards.add(update_index.sub(lock_index).mul(staked_balance).div(UNIT))
 
@@ -1566,7 +1566,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
                 decrease_multiplier.mul(ellapsed_time2).add(decrease_multiplier).div(2)
             )
 
-            estimated_locking_accrued_rewards = ((global_index.sub(update_index)).mul(estimated_multiplier_period2).div(UNIT)).mul(lock_amount).div(UNIT)
+            estimated_locking_accrued_rewards = ((global_index.sub(update_index)).mul(estimated_multiplier_period2)).mul(lock_amount).div(UNIT).div(UNIT)
 
             estimated_accrued_rewards = estimated_locking_accrued_rewards.add(global_index.sub(update_index).mul(staked_balance).div(UNIT))
 


### PR DESCRIPTION
Better precision on some calculations

Prevent estimate next cooldown to div by 0 (if amount is 0, return current cooldown, no transfer == no update)

Fix the DropPerSecond monthly decrease so it doesn't skip months