### PR TITLE
Cooldown Emergency error

### DIFF
--- a/contracts/HolyPaladinToken.sol
+++ b/contracts/HolyPaladinToken.sol
@@ -226,6 +226,7 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
      * @notice Updates the Cooldown for the caller
      */
     function cooldown() external {
+        if(emergency) revert EmergencyBlock();
         require(balanceOf(msg.sender) > 0, "hPAL: No balance");
 
         // Set the current timestamp as start of the user cooldown

--- a/test/3_hPAL_admin_methods.test.ts
+++ b/test/3_hPAL_admin_methods.test.ts
@@ -371,6 +371,10 @@ describe('HolyPaladinToken contract tests - Admin', () => {
             ).to.be.revertedWith('EmergencyBlock')
 
             await expect(
+                hPAL.connect(user1).cooldown()
+            ).to.be.revertedWith('EmergencyBlock')
+
+            await expect(
                 hPAL.connect(user1).unlock()
             ).to.be.revertedWith('EmergencyBlock')
 


### PR DESCRIPTION
Add emergency block on cooldown function, so user can't initiate a cooldown during emergency mode