### PR TITLE
Lock whitelist system for hPAL using SmartWalletChecker

### DIFF
--- a/contracts/HolyPaladinToken.sol
+++ b/contracts/HolyPaladinToken.sol
@@ -6,6 +6,7 @@ import "./open-zeppelin/utils/Ownable.sol";
 import "./open-zeppelin/interfaces/IERC20.sol";
 import "./open-zeppelin/libraries/SafeERC20.sol";
 import "./open-zeppelin/utils/Math.sol";
+import "./utils/SmartWalletChecker.sol";
 
 /** @title Holy Paladin Token (hPAL) contract  */
 /// @author Paladin
@@ -142,8 +143,16 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
     /** @notice Value by which user Bonus Ratio decrease each second  */
     mapping(address => uint256) public userBonusRatioDecrease;
 
+    /** @notice Address of the currect SmartWalletChecker  */
+    address public smartWalletChecker;
+    /** @notice Address of the future SmartWalletChecker  */
+    address public futureSmartWalletChecker;
+
+
     /** @notice Error raised if contract is turned in emergency mode */
     error EmergencyBlock(); 
+
+    error ContractNotAllowed(); 
 
     // Event
 
@@ -172,6 +181,7 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
         address palToken,
         address _admin,
         address _rewardsVault,
+        address _smartWalletChecker,
         uint256 _startDropPerSecond,
         uint256 _endDropPerSecond,
         uint256 _dropDecreaseDuration,
@@ -185,6 +195,9 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
         pal = IERC20(palToken);
 
         transferOwnership(_admin);
+
+        // Set the smartWalletChecker (can be address 0 if we don't want a checker at 1st)
+        smartWalletChecker = _smartWalletChecker;
 
         totalLocks.push(TotalLock(
             0,
@@ -252,6 +265,8 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
      */
     function lock(uint256 amount, uint256 duration) external {
         if(emergency) revert EmergencyBlock();
+        //Check if caller is allowed
+        _assertNotContract(msg.sender);
         // Update user rewards before any change on their balance (staked and locked)
         _updateUserRewards(msg.sender);
         if(delegates[msg.sender] == address(0)){
@@ -267,6 +282,8 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
      */
     function increaseLockDuration(uint256 duration) external {
         if(emergency) revert EmergencyBlock();
+        //Check if caller is allowed
+        _assertNotContract(msg.sender);
         require(userLocks[msg.sender].length != 0, "hPAL: No Lock");
         // Find the current Lock
         uint256 currentUserLockIndex = userLocks[msg.sender].length - 1;
@@ -283,6 +300,8 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
      */
     function increaseLock(uint256 amount) external {
         if(emergency) revert EmergencyBlock();
+        //Check if caller is allowed
+        _assertNotContract(msg.sender);
         require(userLocks[msg.sender].length != 0, "hPAL: No Lock");
         // Find the current Lock
         uint256 currentUserLockIndex = userLocks[msg.sender].length - 1;
@@ -326,6 +345,8 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
      */
     function stakeAndLock(uint256 amount, uint256 duration) external returns(uint256) {
         if(emergency) revert EmergencyBlock();
+        //Check if caller is allowed
+        _assertNotContract(msg.sender);
         // Stake the given amount
         uint256 stakedAmount = _stake(msg.sender, amount);
         // No need to update user rewards since it's done through the _stake() method
@@ -345,6 +366,8 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
      */
     function stakeAndIncreaseLock(uint256 amount, uint256 duration) external returns(uint256) {
         if(emergency) revert EmergencyBlock();
+        //Check if caller is allowed
+        _assertNotContract(msg.sender);
         require(userLocks[msg.sender].length != 0, "hPAL: No Lock");
         // Find the current Lock
         uint256 currentUserLockIndex = userLocks[msg.sender].length - 1;
@@ -702,6 +725,21 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
     }
 
     // ----------------
+
+    // Check if caller is not a smart contract
+    // If it is a contract, check if the contract is allowed by SmartWalletChecker
+    // Revert if not allowed
+    function _assertNotContract(address addr) internal {
+        if(addr != tx.origin){
+            address checker = smartWalletChecker;
+            if(checker != address(0)){
+                if(SmartWalletChecker(checker).check(addr)){
+                    return;
+                }
+                revert ContractNotAllowed();
+            }
+        }
+    }
 
     // Find the user available balance (staked - locked) => the balance that can be transfered
     function _availableBalanceOf(address user) internal view returns(uint256) {
@@ -1433,5 +1471,15 @@ contract HolyPaladinToken is ERC20("Holy Paladin Token", "hPAL"), Ownable {
     function setEndDropPerSecond(uint256 newEndDropPerSecond) external onlyOwner {
         if(block.timestamp < startDropTimestamp + dropDecreaseDuration) revert DecreaseDurationNotOver();
         endDropPerSecond = newEndDropPerSecond;
+    }
+
+
+    function commitSmartWalletChecker(address newSmartWalletChecker) external onlyOwner {
+        futureSmartWalletChecker = newSmartWalletChecker;
+    }
+
+
+    function applySmartWalletChecker() external onlyOwner {
+        smartWalletChecker = futureSmartWalletChecker;
     }
 }

--- a/contracts/test/MockLocker.sol
+++ b/contracts/test/MockLocker.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+
+import "../HolyPaladinToken.sol";
+import "../open-zeppelin/interfaces/IERC20.sol";
+import "../open-zeppelin/libraries/SafeERC20.sol";
+
+/// @notice Mock contract trying to create a Lock over hPAL
+/// Used to test the SmartWalletWhitelist system
+contract MockLocker {
+    using SafeERC20 for IERC20;
+
+    address public pal;
+    address public hPAL;
+
+    uint256 public stakedAmount;
+    uint256 public constant lockDuration = 31557600;
+
+    constructor(address _pal, address _hPAL){
+        pal = _pal;
+        hPAL = _hPAL;
+    }
+
+    function stakeFunds(uint256 amount) external {
+        stakedAmount += amount;
+
+        IERC20(pal).transferFrom(msg.sender, address(this), amount);
+
+        IERC20(pal).safeIncreaseAllowance(hPAL, amount);
+
+        HolyPaladinToken(hPAL).stake(amount);
+    }
+
+    function tryLock() external {
+        HolyPaladinToken(hPAL).lock(stakedAmount, lockDuration);
+    }
+
+    function tryStakeAndLock(uint256 amount) external {
+        stakedAmount += amount;
+
+        IERC20(pal).transferFrom(msg.sender, address(this), amount);
+
+        IERC20(pal).safeIncreaseAllowance(hPAL, amount);
+
+        HolyPaladinToken(hPAL).stakeAndLock(amount, lockDuration);
+    }
+
+    function tryIncreaseLock(uint256 amount) external {
+        stakedAmount += amount;
+
+        IERC20(pal).transferFrom(msg.sender, address(this), amount);
+
+        IERC20(pal).safeIncreaseAllowance(hPAL, amount);
+
+        HolyPaladinToken(hPAL).stake(amount);
+
+        HolyPaladinToken(hPAL).increaseLock(stakedAmount);
+    }
+
+    function tryIncreaseLockDuration() external {
+        HolyPaladinToken(hPAL).increaseLockDuration(lockDuration + 500);
+    }
+
+    function tryStakeAndIncreaseLock(uint256 amount) external {
+        stakedAmount += amount;
+
+        IERC20(pal).transferFrom(msg.sender, address(this), amount);
+
+        IERC20(pal).safeIncreaseAllowance(hPAL, amount);
+
+        HolyPaladinToken(hPAL).stakeAndIncreaseLock(amount, lockDuration);
+    }
+
+    function unlockAll() external {
+        HolyPaladinToken(hPAL).unlock();
+    }
+
+    function withdraw(uint256 amount) external {
+        stakedAmount -= amount;
+
+        HolyPaladinToken(hPAL).unstake(amount, msg.sender);
+    }
+}

--- a/contracts/utils/SmartWalletChecker.sol
+++ b/contracts/utils/SmartWalletChecker.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+
+/// @notice Interface of the `SmartWalletChecker` contracts of the protocol
+interface SmartWalletChecker {
+    function check(address) external view returns (bool);
+}

--- a/contracts/utils/SmartWalletWhitelist.sol
+++ b/contracts/utils/SmartWalletWhitelist.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+
+import "./SmartWalletChecker.sol";
+
+/// @title SmartWalletWhitelist
+/// @author Curve Finance and adapted by Angle Core Team (https://etherscan.io/address/0xca719728ef172d0961768581fdf35cb116e0b7a4#code)
+/// @notice Provides functions to check whether a wallet has been verified or not to own veANGLE
+contract SmartWalletWhitelist {
+    /// @notice Mapping between addresses and whether they are whitelisted or not
+    mapping(address => bool) public wallets;
+    /// @notice Admin address of the contract
+    address public admin;
+    /// @notice Future admin address of the contract
+    //solhint-disable-next-line
+    address public future_admin;
+    /// @notice Contract which works as this contract and that can whitelist addresses
+    address public checker;
+    /// @notice Future address to become checker
+    //solhint-disable-next-line
+    address public future_checker;
+
+    event ApproveWallet(address indexed _wallet);
+    event RevokeWallet(address indexed _wallet);
+
+    /// @notice Constructor of the contract
+    /// @param _admin Admin address of the contract
+    constructor(address _admin) {
+        require(_admin != address(0), "0");
+        admin = _admin;
+    }
+
+    /// @notice Commits to change the admin
+    /// @param _admin New admin of the contract
+    function commitAdmin(address _admin) external {
+        require(msg.sender == admin, "!admin");
+        future_admin = _admin;
+    }
+
+    /// @notice Changes the admin to the admin that has been committed
+    function applyAdmin() external {
+        require(msg.sender == admin, "!admin");
+        require(future_admin != address(0), "admin not set");
+        admin = future_admin;
+    }
+
+    /// @notice Commits to change the checker address
+    /// @param _checker New checker address
+    /// @dev This address can be the zero address in which case there will be no checker
+    function commitSetChecker(address _checker) external {
+        require(msg.sender == admin, "!admin");
+        future_checker = _checker;
+    }
+
+    /// @notice Applies the checker previously committed
+    function applySetChecker() external {
+        require(msg.sender == admin, "!admin");
+        checker = future_checker;
+    }
+
+    /// @notice Approves a wallet
+    /// @param _wallet Wallet to approve
+    function approveWallet(address _wallet) public {
+        require(msg.sender == admin, "!admin");
+        wallets[_wallet] = true;
+
+        emit ApproveWallet(_wallet);
+    }
+
+    /// @notice Revokes a wallet
+    /// @param _wallet Wallet to revoke
+    function revokeWallet(address _wallet) external {
+        require(msg.sender == admin, "!admin");
+        wallets[_wallet] = false;
+
+        emit RevokeWallet(_wallet);
+    }
+
+    /// @notice Checks whether a wallet is whitelisted
+    /// @param _wallet Wallet address to check
+    /// @dev This function can also rely on another SmartWalletChecker (a `checker` to see whether the wallet is whitelisted or not)
+    function check(address _wallet) external view returns (bool) {
+        bool _check = wallets[_wallet];
+        if (_check) {
+            return _check;
+        } else {
+            if (checker != address(0)) {
+                return SmartWalletChecker(checker).check(_wallet);
+            }
+        }
+        return false;
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -15,7 +15,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: "0.8.4",
+        version: "0.8.10",
         settings: {
           optimizer: {
             enabled: true,

--- a/src/test/LockingHPAL.test.sol
+++ b/src/test/LockingHPAL.test.sol
@@ -39,6 +39,7 @@ contract LockingHPALTest is DSTest {
             address(pal),
             address(this),
             address(this),
+            address(0),
             startDropPerSecond,
             endDropPerSecond,
             dropDecreaseDuration,

--- a/src/test/StakingHPAL.test.sol
+++ b/src/test/StakingHPAL.test.sol
@@ -39,6 +39,7 @@ contract StakingHPALTest is DSTest {
             address(pal),
             address(this),
             address(this),
+            address(0),
             startDropPerSecond,
             endDropPerSecond,
             dropDecreaseDuration,

--- a/test/0_HPAL_staking.test.ts
+++ b/test/0_HPAL_staking.test.ts
@@ -64,6 +64,7 @@ describe('HolyPaladinToken contract tests - Base & Staking', () => {
             token.address,
             admin.address,
             mockRewardsVault.address,
+            ethers.constants.AddressZero,
             startDropPerSecond,
             endDropPerSecond,
             dropDecreaseDuration,
@@ -87,6 +88,9 @@ describe('HolyPaladinToken contract tests - Base & Staking', () => {
         expect(tokenDecimals).to.be.eq(18)
 
         expect(await hPAL.pal()).to.be.eq(token.address)
+        
+        expect(await hPAL.smartWalletChecker()).to.be.eq(ethers.constants.AddressZero)
+        expect(await hPAL.futureSmartWalletChecker()).to.be.eq(ethers.constants.AddressZero)
 
         expect(await hPAL.kickRatioPerWeek()).to.be.eq(1000)
         expect(await hPAL.bonusLockVoteRatio()).to.be.eq(ethers.utils.parseEther('0.5'))

--- a/test/1_HPAL_locking.test.ts
+++ b/test/1_HPAL_locking.test.ts
@@ -69,6 +69,7 @@ describe('HolyPaladinToken contract tests - Locking', () => {
             token.address,
             admin.address,
             mockRewardsVault.address,
+            ethers.constants.AddressZero,
             startDropPerSecond,
             endDropPerSecond,
             dropDecreaseDuration,
@@ -96,6 +97,9 @@ describe('HolyPaladinToken contract tests - Locking', () => {
         expect(await hPAL.kickRatioPerWeek()).to.be.eq(1000)
         expect(await hPAL.bonusLockVoteRatio()).to.be.eq(ethers.utils.parseEther('0.5'))
         expect(await hPAL.emergency()).to.be.false
+        
+        expect(await hPAL.smartWalletChecker()).to.be.eq(ethers.constants.AddressZero)
+        expect(await hPAL.futureSmartWalletChecker()).to.be.eq(ethers.constants.AddressZero)
 
         //constants
         expect(await hPAL.COOLDOWN_PERIOD()).to.be.eq(864000)

--- a/test/2_hPAL_rewards.test.ts
+++ b/test/2_hPAL_rewards.test.ts
@@ -83,6 +83,7 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
             token.address,
             admin.address,
             reserve.address,
+            ethers.constants.AddressZero,
             startDropPerSecond,
             endDropPerSecond,
             dropDecreaseDuration,
@@ -111,6 +112,9 @@ describe('HolyPaladinToken contract tests - Rewards', () => {
         expect(await hPAL.startDropTimestamp()).to.be.eq(deploy_ts)
 
         expect(await hPAL.rewardIndex()).to.be.eq(0)
+        
+        expect(await hPAL.smartWalletChecker()).to.be.eq(ethers.constants.AddressZero)
+        expect(await hPAL.futureSmartWalletChecker()).to.be.eq(ethers.constants.AddressZero)
 
         expect(await hPAL.startDropPerSecond()).to.be.eq(startDropPerSecond)
         expect(await hPAL.endDropPerSecond()).to.be.eq(endDropPerSecond)

--- a/test/3_hPAL_admin_methods.test.ts
+++ b/test/3_hPAL_admin_methods.test.ts
@@ -65,6 +65,7 @@ describe('HolyPaladinToken contract tests - Admin', () => {
             token.address,
             admin.address,
             mockRewardsVault.address,
+            ethers.constants.AddressZero,
             startDropPerSecond,
             endDropPerSecond,
             dropDecreaseDuration,
@@ -88,6 +89,9 @@ describe('HolyPaladinToken contract tests - Admin', () => {
         expect(tokenDecimals).to.be.eq(18)
 
         expect(await hPAL.pal()).to.be.eq(token.address)
+        
+        expect(await hPAL.smartWalletChecker()).to.be.eq(ethers.constants.AddressZero)
+        expect(await hPAL.futureSmartWalletChecker()).to.be.eq(ethers.constants.AddressZero)
 
         expect(await hPAL.kickRatioPerWeek()).to.be.eq(1000)
         expect(await hPAL.bonusLockVoteRatio()).to.be.eq(ethers.utils.parseEther('0.5'))

--- a/test/4_HPAL-whitelist.test.ts
+++ b/test/4_HPAL-whitelist.test.ts
@@ -1,0 +1,801 @@
+const hre = require("hardhat");
+import { ethers, waffle } from "hardhat";
+import chai from "chai";
+import { solidity } from "ethereum-waffle";
+import { PaladinToken } from "../typechain/PaladinToken";
+import { HolyPaladinToken } from "../typechain/HolyPaladinToken";
+import { SmartWalletWhitelist } from "../typechain/SmartWalletWhitelist";
+import { MockLocker } from "../typechain/MockLocker";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { ContractFactory } from "@ethersproject/contracts";
+import { advanceTime } from "./utils/utils";
+
+chai.use(solidity);
+const { expect } = chai;
+
+
+const mineBlocks = async (n: number): Promise<any> => {
+    for (let i = 0; i < n; i++) {
+        await ethers.provider.send("evm_mine", [])
+    }
+    return Promise.resolve()
+}
+
+let tokenFactory: ContractFactory
+let hPAL_Factory: ContractFactory
+let checkerFactory: ContractFactory
+let mockLockerFactory: ContractFactory
+
+const mint_amount = ethers.utils.parseEther('10000000') // 10 M tokens
+
+const startDropPerSecond = ethers.utils.parseEther('0.0005')
+const endDropPerSecond = ethers.utils.parseEther('0.00001')
+
+const dropDecreaseDuration = 63115200
+
+const baseLockBonusRatio = ethers.utils.parseEther('1')
+const minLockBonusRatio = ethers.utils.parseEther('2')
+const maxLockBonusRatio = ethers.utils.parseEther('6')
+
+describe('HolyPaladinToken contract tests - Admin', () => {
+    let deployer: SignerWithAddress
+    let admin: SignerWithAddress
+    let recipient: SignerWithAddress
+    let mockRewardsVault: SignerWithAddress
+    let mockSecondaryChecker: SignerWithAddress
+    let user1: SignerWithAddress
+    let user2: SignerWithAddress
+    let newAdmin: SignerWithAddress
+
+    let token: PaladinToken
+
+    let hPAL: HolyPaladinToken
+
+    let checker: SmartWalletWhitelist
+
+    let locker: MockLocker
+
+    before(async () => {
+        tokenFactory = await ethers.getContractFactory("PaladinToken");
+        hPAL_Factory = await ethers.getContractFactory("HolyPaladinToken");
+        checkerFactory = await ethers.getContractFactory("SmartWalletWhitelist");
+        mockLockerFactory = await ethers.getContractFactory("MockLocker");
+    })
+
+
+    beforeEach(async () => {
+        [deployer, admin, newAdmin, recipient, mockRewardsVault, mockSecondaryChecker, user1, user2] = await ethers.getSigners();
+
+        token = (await tokenFactory.connect(deployer).deploy(mint_amount, admin.address, recipient.address)) as PaladinToken;
+        await token.deployed();
+
+        await token.connect(admin).setTransfersAllowed(true);
+
+        hPAL = (await hPAL_Factory.connect(deployer).deploy(
+            token.address,
+            admin.address,
+            mockRewardsVault.address,
+            ethers.constants.AddressZero,
+            startDropPerSecond,
+            endDropPerSecond,
+            dropDecreaseDuration,
+            baseLockBonusRatio,
+            minLockBonusRatio,
+            maxLockBonusRatio
+        )) as HolyPaladinToken;
+        await hPAL.deployed();
+
+        checker = (await checkerFactory.connect(deployer).deploy(admin.address)) as SmartWalletWhitelist;
+        await checker.deployed();
+
+        locker = (await mockLockerFactory.connect(deployer).deploy(token.address, hPAL.address)) as MockLocker;
+        await locker.deployed();
+    });
+
+
+    it(' should be deployed & have correct parameters', async () => {
+        expect(hPAL.address).to.properAddress
+
+        expect(await hPAL.pal()).to.be.eq(token.address)
+        expect(await hPAL.emergency()).to.be.false
+        
+        expect(await hPAL.smartWalletChecker()).to.be.eq(ethers.constants.AddressZero)
+        expect(await hPAL.futureSmartWalletChecker()).to.be.eq(ethers.constants.AddressZero)
+        
+
+        expect(checker.address).to.properAddress
+
+        expect(await checker.admin()).to.be.eq(admin.address)
+        expect(await checker.future_admin()).to.be.eq(ethers.constants.AddressZero)
+        expect(await checker.checker()).to.be.eq(ethers.constants.AddressZero)
+        expect(await checker.future_checker()).to.be.eq(ethers.constants.AddressZero)
+
+
+        expect(await checker.wallets(locker.address)).to.be.false
+
+    });
+
+    describe('HolyPaladinToken - Commit & Apply Checker', async () => {
+
+        it(' should set the correct future checker', async () => {
+
+            expect(await hPAL.futureSmartWalletChecker()).to.be.eq(ethers.constants.AddressZero)
+
+            await hPAL.connect(admin).commitSmartWalletChecker(checker.address)
+
+            expect(await hPAL.futureSmartWalletChecker()).to.be.eq(checker.address)
+
+        });
+
+        it(' should update the correct new checker', async () => {
+
+            await hPAL.connect(admin).commitSmartWalletChecker(checker.address)
+
+            expect(await hPAL.smartWalletChecker()).to.be.eq(ethers.constants.AddressZero)
+
+            await hPAL.connect(admin).applySmartWalletChecker()
+
+            expect(await hPAL.smartWalletChecker()).to.be.eq(checker.address)
+
+        });
+
+        it(' should allow to set future checker as address 0', async () => {
+
+            await hPAL.connect(admin).commitSmartWalletChecker(checker.address)
+
+            expect(await hPAL.futureSmartWalletChecker()).to.be.eq(checker.address)
+
+            await hPAL.connect(admin).applySmartWalletChecker()
+
+            expect(await hPAL.smartWalletChecker()).to.be.eq(checker.address)
+
+            expect(await hPAL.futureSmartWalletChecker()).to.be.eq(checker.address)
+
+            await hPAL.connect(admin).commitSmartWalletChecker(ethers.constants.AddressZero)
+
+            expect(await hPAL.futureSmartWalletChecker()).to.be.eq(ethers.constants.AddressZero)
+
+        });
+
+        it(' should allow to reset checker to address 0', async () => {
+
+            await hPAL.connect(admin).commitSmartWalletChecker(checker.address)
+
+            expect(await hPAL.smartWalletChecker()).to.be.eq(ethers.constants.AddressZero)
+
+            await hPAL.connect(admin).applySmartWalletChecker()
+
+            expect(await hPAL.smartWalletChecker()).to.be.eq(checker.address)
+
+            await hPAL.connect(admin).commitSmartWalletChecker(ethers.constants.AddressZero)
+
+            await hPAL.connect(admin).applySmartWalletChecker()
+
+            expect(await hPAL.smartWalletChecker()).to.be.eq(ethers.constants.AddressZero)
+
+        });
+
+        it(' should only be callable by admin', async () => {
+
+            await expect(
+                hPAL.connect(user1).commitSmartWalletChecker(checker.address)
+            ).to.be.revertedWith('Ownable: caller is not the owner')
+
+            await expect(
+                hPAL.connect(user1).applySmartWalletChecker()
+            ).to.be.revertedWith('Ownable: caller is not the owner')
+
+        });
+
+    });
+
+
+    describe('SmartWalletWhitelist - Approve & Revoke wallets', async () => {
+
+        it(' should approve the wallet (& emit the correct event)', async () => {
+
+            expect(await checker.wallets(locker.address)).to.be.false
+
+            const approval_tx = await checker.connect(admin).approveWallet(locker.address)
+
+            await expect(approval_tx)
+                .to.emit(checker, 'ApproveWallet')
+                .withArgs(locker.address);
+
+            expect(await checker.wallets(locker.address)).to.be.true
+
+        });
+
+        it(' should not change previous approved wallets', async () => {
+
+            await checker.connect(admin).approveWallet(locker.address)
+
+            expect(await checker.wallets(locker.address)).to.be.true
+            expect(await checker.wallets(mockRewardsVault.address)).to.be.false
+
+            await checker.connect(admin).approveWallet(mockRewardsVault.address)
+
+            expect(await checker.wallets(locker.address)).to.be.true
+            expect(await checker.wallets(mockRewardsVault.address)).to.be.true
+
+        });
+
+        it(' should revoke wallet approval (& emit the correct Event)', async () => {
+
+            await checker.connect(admin).approveWallet(locker.address)
+
+            expect(await checker.wallets(locker.address)).to.be.true
+
+            const revoke_tx = await checker.connect(admin).revokeWallet(locker.address)
+
+            await expect(revoke_tx)
+                .to.emit(checker, 'RevokeWallet')
+                .withArgs(locker.address);
+
+            expect(await checker.wallets(locker.address)).to.be.false
+
+        });
+
+        it(' should not revoke other wallets approval', async () => {
+
+            await checker.connect(admin).approveWallet(locker.address)
+            await checker.connect(admin).approveWallet(mockRewardsVault.address)
+
+            expect(await checker.wallets(locker.address)).to.be.true
+            expect(await checker.wallets(mockRewardsVault.address)).to.be.true
+
+            await checker.connect(admin).revokeWallet(locker.address)
+
+            expect(await checker.wallets(locker.address)).to.be.false
+            expect(await checker.wallets(mockRewardsVault.address)).to.be.true
+
+        });
+
+        it(' should only be callable by admin', async () => {
+
+            await expect(
+                checker.connect(user1).approveWallet(locker.address)
+            ).to.be.revertedWith('!admin')
+
+            await expect(
+                checker.connect(user1).revokeWallet(locker.address)
+            ).to.be.revertedWith('!admin')
+
+        });
+
+    });
+
+
+    describe('HolyPaladinToken - Checker not set', async () => {
+
+        const stake_amount = ethers.utils.parseEther('1000')
+
+        beforeEach(async () => {
+
+            await token.connect(recipient).transfer(user1.address, ethers.utils.parseEther('10000'))
+
+            await token.connect(user1).approve(locker.address, ethers.utils.parseEther('10000'))
+
+            await locker.connect(user1).stakeFunds(stake_amount)
+
+        });
+
+        it(' should not block contract to lock', async () => {
+
+            const tx = await locker.connect(user1).tryLock()
+
+            const tx_block = (await tx).blockNumber
+            const tx_timestamp = (await ethers.provider.getBlock(tx_block || 0)).timestamp
+
+            const contract_lock = await hPAL.getUserLock(locker.address)
+
+            expect(contract_lock.amount).to.be.eq(stake_amount)
+            expect(contract_lock.startTimestamp).to.be.eq(tx_timestamp)
+            expect(contract_lock.duration).to.be.eq(31557600)
+            expect(contract_lock.fromBlock).to.be.eq(tx_block)
+
+        });
+
+        it(' should not block contract to increase', async () => {
+
+            await locker.connect(user1).tryLock()
+
+            const contract_previous_lock = await hPAL.getUserLock(locker.address)
+
+            const tx = await locker.connect(user1).tryIncreaseLock(ethers.utils.parseEther('500'))
+
+            const tx_block = (await tx).blockNumber
+            const tx_timestamp = (await ethers.provider.getBlock(tx_block || 0)).timestamp
+
+            const contract_lock = await hPAL.getUserLock(locker.address)
+
+            expect(contract_lock.amount).to.be.eq(stake_amount.add(ethers.utils.parseEther('500')))
+            expect(contract_lock.startTimestamp).to.be.eq(contract_previous_lock.startTimestamp)
+            expect(contract_lock.duration).to.be.eq(31557600)
+            expect(contract_lock.fromBlock).to.be.eq(tx_block)
+
+            const tx2 = await locker.connect(user1).tryIncreaseLockDuration()
+
+            const tx2_block = (await tx2).blockNumber
+            const tx2_timestamp = (await ethers.provider.getBlock(tx2_block || 0)).timestamp
+
+            const contract_lock2 = await hPAL.getUserLock(locker.address)
+
+            expect(contract_lock2.amount).to.be.eq(stake_amount.add(ethers.utils.parseEther('500')))
+            expect(contract_lock2.startTimestamp).to.be.eq(tx2_timestamp)
+            expect(contract_lock2.duration).to.be.eq(31558100)
+            expect(contract_lock2.fromBlock).to.be.eq(tx2_block)
+
+        });
+
+        it(' should not block contract to stake and lock', async () => {
+
+            const tx = await locker.connect(user1).tryStakeAndLock(stake_amount)
+
+            const tx_block = (await tx).blockNumber
+            const tx_timestamp = (await ethers.provider.getBlock(tx_block || 0)).timestamp
+
+            const contract_lock = await hPAL.getUserLock(locker.address)
+
+            expect(contract_lock.amount).to.be.eq(stake_amount)
+            expect(contract_lock.startTimestamp).to.be.eq(tx_timestamp)
+            expect(contract_lock.duration).to.be.eq(31557600)
+            expect(contract_lock.fromBlock).to.be.eq(tx_block)
+
+        });
+
+        it(' should not block contract to stake and increase lock', async () => {
+
+            await locker.connect(user1).tryLock()
+
+            const contract_previous_lock = await hPAL.getUserLock(locker.address)
+
+            const tx = await locker.connect(user1).tryStakeAndIncreaseLock(ethers.utils.parseEther('500'))
+
+            const tx_block = (await tx).blockNumber
+            const tx_timestamp = (await ethers.provider.getBlock(tx_block || 0)).timestamp
+
+            const contract_lock = await hPAL.getUserLock(locker.address)
+
+            expect(contract_lock.amount).to.be.eq(stake_amount.add(ethers.utils.parseEther('500')))
+            expect(contract_lock.startTimestamp).to.be.eq(contract_previous_lock.startTimestamp)
+            expect(contract_lock.duration).to.be.eq(31557600)
+            expect(contract_lock.fromBlock).to.be.eq(tx_block)
+
+        });
+
+    });
+
+
+    describe('HolyPaladinToken - Checker set', async () => {
+
+        const stake_amount = ethers.utils.parseEther('1000')
+
+        beforeEach(async () => {
+
+            await token.connect(recipient).transfer(user1.address, ethers.utils.parseEther('10000'))
+
+            await token.connect(user1).approve(locker.address, ethers.utils.parseEther('10000'))
+
+            await hPAL.connect(admin).commitSmartWalletChecker(checker.address)
+
+            await hPAL.connect(admin).applySmartWalletChecker()
+
+            await locker.connect(user1).stakeFunds(stake_amount)
+
+        });
+
+        it(' should block smart contract that is not allowed to lock', async () => {
+
+            await expect(
+                locker.connect(user1).tryLock()
+            ).to.be.revertedWith('ContractNotAllowed')
+
+            await expect(
+                locker.connect(user1).tryStakeAndLock(stake_amount)
+            ).to.be.revertedWith('ContractNotAllowed')
+
+            await expect(
+                locker.connect(user1).tryIncreaseLock(ethers.utils.parseEther('500'))
+            ).to.be.revertedWith('ContractNotAllowed')
+
+            await expect(
+                locker.connect(user1).tryIncreaseLockDuration()
+            ).to.be.revertedWith('ContractNotAllowed')
+
+            await expect(
+                locker.connect(user1).tryStakeAndIncreaseLock(ethers.utils.parseEther('500'))
+            ).to.be.revertedWith('ContractNotAllowed')
+
+        });
+
+        it(' should allow an approved contract to lock', async () => {
+
+            await checker.connect(admin).approveWallet(locker.address)
+
+            const tx = await locker.connect(user1).tryLock()
+
+            const tx_block = (await tx).blockNumber
+            const tx_timestamp = (await ethers.provider.getBlock(tx_block || 0)).timestamp
+
+            const contract_lock = await hPAL.getUserLock(locker.address)
+
+            expect(contract_lock.amount).to.be.eq(stake_amount)
+            expect(contract_lock.startTimestamp).to.be.eq(tx_timestamp)
+            expect(contract_lock.duration).to.be.eq(31557600)
+            expect(contract_lock.fromBlock).to.be.eq(tx_block)
+
+            const tx2 = await locker.connect(user1).tryIncreaseLock(ethers.utils.parseEther('500'))
+
+            const tx2_block = (await tx2).blockNumber
+            const tx2_timestamp = (await ethers.provider.getBlock(tx2_block || 0)).timestamp
+
+            const contract_lock2 = await hPAL.getUserLock(locker.address)
+
+            expect(contract_lock2.amount).to.be.eq(stake_amount.add(ethers.utils.parseEther('500')))
+            expect(contract_lock2.startTimestamp).to.be.eq(tx_timestamp)
+            expect(contract_lock2.duration).to.be.eq(31557600)
+            expect(contract_lock2.fromBlock).to.be.eq(tx2_block)
+
+            const tx3 = await locker.connect(user1).tryIncreaseLockDuration()
+
+            const tx3_block = (await tx3).blockNumber
+            const tx3_timestamp = (await ethers.provider.getBlock(tx3_block || 0)).timestamp
+
+            const contract_lock3 = await hPAL.getUserLock(locker.address)
+
+            expect(contract_lock3.amount).to.be.eq(stake_amount.add(ethers.utils.parseEther('500')))
+            expect(contract_lock3.startTimestamp).to.be.eq(tx3_timestamp)
+            expect(contract_lock3.duration).to.be.eq(31558100)
+            expect(contract_lock3.fromBlock).to.be.eq(tx3_block)
+
+        });
+
+        it(' should not block an user to lock', async () => {
+
+            const lock_amount = ethers.utils.parseEther('700')
+
+            const lock_duration = 31557600
+
+            await token.connect(user1).approve(hPAL.address, stake_amount)
+
+            await hPAL.connect(user1).stake(stake_amount)
+
+            const lock_tx = await hPAL.connect(user1).lock(lock_amount, lock_duration)
+
+            const current_totalLocked = await hPAL.currentTotalLocked()
+
+            const tx_block = (await lock_tx).blockNumber
+            const tx_timestamp = (await ethers.provider.getBlock(tx_block || 0)).timestamp
+
+            await expect(lock_tx)
+                .to.emit(hPAL, 'Lock')
+                .withArgs(user1.address, lock_amount, tx_timestamp, lock_duration, current_totalLocked);
+
+            const user_lock = await hPAL.getUserLock(user1.address)
+
+            expect(user_lock.amount).to.be.eq(lock_amount)
+            expect(user_lock.startTimestamp).to.be.eq(tx_timestamp)
+            expect(user_lock.duration).to.be.eq(lock_duration)
+            expect(user_lock.fromBlock).to.be.eq(tx_block)
+
+        });
+
+    });
+
+
+    describe('HolyPaladinToken - Checker not set, then set', async () => {
+
+        const stake_amount = ethers.utils.parseEther('1000')
+
+        beforeEach(async () => {
+
+            await token.connect(recipient).transfer(user1.address, ethers.utils.parseEther('10000'))
+
+            await token.connect(user1).approve(locker.address, ethers.utils.parseEther('10000'))
+
+            await locker.connect(user1).stakeFunds(stake_amount)
+
+        });
+
+        it(' should not allow the contract to lock after checker was set', async () => {
+
+            const tx = await locker.connect(user1).tryLock()
+
+            const tx_block = (await tx).blockNumber
+            const tx_timestamp = (await ethers.provider.getBlock(tx_block || 0)).timestamp
+
+            const contract_lock = await hPAL.getUserLock(locker.address)
+
+            expect(contract_lock.amount).to.be.eq(stake_amount)
+            expect(contract_lock.startTimestamp).to.be.eq(tx_timestamp)
+            expect(contract_lock.duration).to.be.eq(31557600)
+            expect(contract_lock.fromBlock).to.be.eq(tx_block)
+
+            await hPAL.connect(admin).commitSmartWalletChecker(checker.address)
+
+            await hPAL.connect(admin).applySmartWalletChecker()
+
+            await expect(
+                locker.connect(user1).tryLock()
+            ).to.be.revertedWith('ContractNotAllowed')
+
+            await expect(
+                locker.connect(user1).tryStakeAndLock(stake_amount)
+            ).to.be.revertedWith('ContractNotAllowed')
+
+            await expect(
+                locker.connect(user1).tryIncreaseLock(ethers.utils.parseEther('500'))
+            ).to.be.revertedWith('ContractNotAllowed')
+
+            await expect(
+                locker.connect(user1).tryIncreaseLockDuration()
+            ).to.be.revertedWith('ContractNotAllowed')
+
+            await expect(
+                locker.connect(user1).tryStakeAndIncreaseLock(ethers.utils.parseEther('500'))
+            ).to.be.revertedWith('ContractNotAllowed')
+
+        });
+
+        it(' should allow the approved contract to lock after checker was set', async () => {
+
+            const tx = await locker.connect(user1).tryLock()
+
+            const tx_block = (await tx).blockNumber
+            const tx_timestamp = (await ethers.provider.getBlock(tx_block || 0)).timestamp
+
+            const contract_lock = await hPAL.getUserLock(locker.address)
+
+            expect(contract_lock.amount).to.be.eq(stake_amount)
+            expect(contract_lock.startTimestamp).to.be.eq(tx_timestamp)
+            expect(contract_lock.duration).to.be.eq(31557600)
+            expect(contract_lock.fromBlock).to.be.eq(tx_block)
+
+            await hPAL.connect(admin).commitSmartWalletChecker(checker.address)
+
+            await hPAL.connect(admin).applySmartWalletChecker()
+
+            await checker.connect(admin).approveWallet(locker.address)
+
+            const tx2 = await locker.connect(user1).tryIncreaseLock(ethers.utils.parseEther('500'))
+
+            const tx2_block = (await tx2).blockNumber
+            const tx2_timestamp = (await ethers.provider.getBlock(tx2_block || 0)).timestamp
+
+            const contract_lock2 = await hPAL.getUserLock(locker.address)
+
+            expect(contract_lock2.amount).to.be.eq(stake_amount.add(ethers.utils.parseEther('500')))
+            expect(contract_lock2.startTimestamp).to.be.eq(tx_timestamp)
+            expect(contract_lock2.duration).to.be.eq(31557600)
+            expect(contract_lock2.fromBlock).to.be.eq(tx2_block)
+
+            const tx3 = await locker.connect(user1).tryIncreaseLockDuration()
+
+            const tx3_block = (await tx3).blockNumber
+            const tx3_timestamp = (await ethers.provider.getBlock(tx3_block || 0)).timestamp
+
+            const contract_lock3 = await hPAL.getUserLock(locker.address)
+
+            expect(contract_lock3.amount).to.be.eq(stake_amount.add(ethers.utils.parseEther('500')))
+            expect(contract_lock3.startTimestamp).to.be.eq(tx3_timestamp)
+            expect(contract_lock3.duration).to.be.eq(31558100)
+            expect(contract_lock3.fromBlock).to.be.eq(tx3_block)
+
+        });
+
+    });
+
+
+    describe('HolyPaladinToken - Check set, then removed', async () => {
+
+        const stake_amount = ethers.utils.parseEther('1000')
+
+        beforeEach(async () => {
+
+            await token.connect(recipient).transfer(user1.address, ethers.utils.parseEther('10000'))
+
+            await token.connect(user1).approve(locker.address, ethers.utils.parseEther('10000'))
+
+            await hPAL.connect(admin).commitSmartWalletChecker(checker.address)
+
+            await hPAL.connect(admin).applySmartWalletChecker()
+
+            await locker.connect(user1).stakeFunds(stake_amount)
+
+        });
+
+        it(' should allow the smart contract to lock after the checker was removed', async () => {
+
+            await expect(
+                locker.connect(user1).tryLock()
+            ).to.be.revertedWith('ContractNotAllowed')
+
+            await expect(
+                locker.connect(user1).tryStakeAndLock(stake_amount)
+            ).to.be.revertedWith('ContractNotAllowed')
+
+            await expect(
+                locker.connect(user1).tryIncreaseLock(ethers.utils.parseEther('500'))
+            ).to.be.revertedWith('ContractNotAllowed')
+
+            await expect(
+                locker.connect(user1).tryIncreaseLockDuration()
+            ).to.be.revertedWith('ContractNotAllowed')
+
+            await expect(
+                locker.connect(user1).tryStakeAndIncreaseLock(ethers.utils.parseEther('500'))
+            ).to.be.revertedWith('ContractNotAllowed')
+
+            await hPAL.connect(admin).commitSmartWalletChecker(ethers.constants.AddressZero)
+
+            await hPAL.connect(admin).applySmartWalletChecker()
+
+            const tx = await locker.connect(user1).tryLock()
+
+            const tx_block = (await tx).blockNumber
+            const tx_timestamp = (await ethers.provider.getBlock(tx_block || 0)).timestamp
+
+            const contract_lock = await hPAL.getUserLock(locker.address)
+
+            expect(contract_lock.amount).to.be.eq(stake_amount)
+            expect(contract_lock.startTimestamp).to.be.eq(tx_timestamp)
+            expect(contract_lock.duration).to.be.eq(31557600)
+            expect(contract_lock.fromBlock).to.be.eq(tx_block)
+
+            const tx2 = await locker.connect(user1).tryIncreaseLock(ethers.utils.parseEther('500'))
+
+            const tx2_block = (await tx2).blockNumber
+            const tx2_timestamp = (await ethers.provider.getBlock(tx2_block || 0)).timestamp
+
+            const contract_lock2 = await hPAL.getUserLock(locker.address)
+
+            expect(contract_lock2.amount).to.be.eq(stake_amount.add(ethers.utils.parseEther('500')))
+            expect(contract_lock2.startTimestamp).to.be.eq(tx_timestamp)
+            expect(contract_lock2.duration).to.be.eq(31557600)
+            expect(contract_lock2.fromBlock).to.be.eq(tx2_block)
+
+        });
+
+    });
+
+
+    describe('SmartWalletWhitelist - Commit & Apply admin', async () => {
+
+        it(' should commit the correct new admin', async () => {
+
+            expect(await checker.future_admin()).to.be.eq(ethers.constants.AddressZero)
+
+            await checker.connect(admin).commitAdmin(newAdmin.address)
+
+            expect(await checker.future_admin()).to.be.eq(newAdmin.address)
+
+        });
+
+        it(' should apply the new admin correctly', async () => {
+
+            await checker.connect(admin).commitAdmin(newAdmin.address)
+
+            expect(await checker.admin()).to.be.eq(admin.address)
+
+            await checker.connect(admin).applyAdmin()
+
+            expect(await checker.admin()).to.be.eq(newAdmin.address)
+
+            await expect(
+                checker.connect(admin).commitAdmin(admin.address)
+            ).to.be.revertedWith('!admin')
+
+        });
+
+        it(' should fail to apply if future admin is not set', async () => {
+
+            await expect(
+                checker.connect(admin).applyAdmin()
+            ).to.be.revertedWith('admin not set')
+
+        });
+
+        it(' should only be callable by current admin', async () => {
+
+            await expect(
+                checker.connect(user1).commitAdmin(newAdmin.address)
+            ).to.be.revertedWith('!admin')
+
+            await expect(
+                checker.connect(user1).applyAdmin()
+            ).to.be.revertedWith('!admin')
+
+        });
+
+    });
+
+
+    describe('SmartWalletWhitelist - Commit & Apply checker', async () => {
+
+        it(' should set the correct future checker', async () => {
+
+            expect(await checker.future_checker()).to.be.eq(ethers.constants.AddressZero)
+
+            await checker.connect(admin).commitSetChecker(mockSecondaryChecker.address)
+
+            expect(await checker.future_checker()).to.be.eq(mockSecondaryChecker.address)
+
+        });
+
+        it(' should apply the new checker correctly', async () => {
+
+            await checker.connect(admin).commitSetChecker(mockSecondaryChecker.address)
+
+            expect(await checker.checker()).to.be.eq(ethers.constants.AddressZero)
+
+            await checker.connect(admin).applySetChecker()
+
+            expect(await checker.checker()).to.be.eq(mockSecondaryChecker.address)
+
+        });
+
+        it(' should allow to set the future checker to address 0', async () => {
+
+            expect(await checker.future_checker()).to.be.eq(ethers.constants.AddressZero)
+
+            await checker.connect(admin).commitSetChecker(mockSecondaryChecker.address)
+
+            expect(await checker.future_checker()).to.be.eq(mockSecondaryChecker.address)
+
+            await checker.connect(admin).commitSetChecker(ethers.constants.AddressZero)
+
+            expect(await checker.future_checker()).to.be.eq(ethers.constants.AddressZero)
+
+        });
+
+        it(' should remove the checker (reset to address 0)', async () => {
+
+            await checker.connect(admin).commitSetChecker(mockSecondaryChecker.address)
+
+            expect(await checker.checker()).to.be.eq(ethers.constants.AddressZero)
+
+            await checker.connect(admin).applySetChecker()
+
+            expect(await checker.checker()).to.be.eq(mockSecondaryChecker.address)
+
+            await checker.connect(admin).commitSetChecker(ethers.constants.AddressZero)
+
+            await checker.connect(admin).applySetChecker()
+
+            expect(await checker.checker()).to.be.eq(ethers.constants.AddressZero)
+
+        });
+
+        it(' should only be callable by admin', async () => {
+
+            await expect(
+                checker.connect(user1).commitSetChecker(mockSecondaryChecker.address)
+            ).to.be.revertedWith('!admin')
+
+            await expect(
+                checker.connect(user1).applySetChecker()
+            ).to.be.revertedWith('!admin')
+
+        });
+
+        it(' should use the set checker for extra check', async () => {
+
+            let otherChecker = (await checkerFactory.connect(deployer).deploy(admin.address)) as SmartWalletWhitelist;
+            await otherChecker.deployed();
+
+            await otherChecker.connect(admin).approveWallet(locker.address)
+
+            await checker.connect(admin).commitSetChecker(otherChecker.address)
+
+            await checker.connect(admin).applySetChecker()
+
+            const result = await checker.check(locker.address)
+
+            expect(result).to.be.true
+
+        });
+
+    });
+
+});


### PR DESCRIPTION
Added a whitelist logic that can be applied (and removed) to block contracts to Lock.
Based on SmartWalletChecker, using the whitelist version (taken from veCRV, veANGLE & veFXS). This will allow to activate the Whitelist (can be added straight at deploy), and approve contract that will get permission to lock.

Added tests for that system, to activate/deactivate the checker, approve/revoke wallets.